### PR TITLE
Ensure Hotjar ID is present; fixes #1

### DIFF
--- a/admin/views/wp-hotjar-view.php
+++ b/admin/views/wp-hotjar-view.php
@@ -15,6 +15,8 @@
     <label for="wp_hotjar_id">Hotjar ID</label><br />
     <input type="text" name="wp_hotjar[hotjar_id]" id="wp_hotjar_id"
       value="<?php echo $settings['hotjar_id']; ?>" maxlength="10" />
+    <br />
+    (Leave blank to disable)
   </div>
 
   <br />

--- a/classes/class-wp-hotjar-connector.php
+++ b/classes/class-wp-hotjar-connector.php
@@ -20,7 +20,7 @@ class WP_Hotjar_Connector {
     $settings = get_option( 'wp_hotjar' );
     $is_admin = is_admin() || current_user_can('manage_options');
 
-    if (!is_array($settings) || ($is_admin && 'yes' === $settings['disable_for_admin'])) {
+    if (!is_array($settings) || ($is_admin && 'yes' === $settings['disable_for_admin']) || !$settings['hotjar_id'] ) {
       return;
     }
 

--- a/classes/class-wp-hotjar-connector.php
+++ b/classes/class-wp-hotjar-connector.php
@@ -20,7 +20,12 @@ class WP_Hotjar_Connector {
     $settings = get_option( 'wp_hotjar' );
     $is_admin = is_admin() || current_user_can('manage_options');
 
-    if (!is_array($settings) || ($is_admin && 'yes' === $settings['disable_for_admin']) || !$settings['hotjar_id'] ) {
+    $hotjar_id = trim($settings['hotjar_id']);
+    if (!$hotjar_id) {
+      return;
+    }
+
+    if (!is_array($settings) || ($is_admin && 'yes' === $settings['disable_for_admin'])) {
       return;
     }
 
@@ -28,7 +33,7 @@ class WP_Hotjar_Connector {
     <script>
       (function(h,o,t,j,a,r){
         h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:" . $settings['hotjar_id'] . ",hjsv:5};
+        h._hjSettings={hjid:" . $hotjar_id . ",hjsv:5};
         a=o.getElementsByTagName('head')[0];
         r=o.createElement('script');r.async=1;
         r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;


### PR DESCRIPTION
Checks if the variable is present. Also informs the user that they can disable printing the JS by leaving the ID field blank on the admin settings page.